### PR TITLE
Delete the /etc/timezone before setting it to avoid permissions issues

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,5 +26,10 @@
     name: "{{ chrony_tzdata_package }}"
     state: present
 
+- name: Delete /etc/localtime file to avoid permission conflicts
+  file:
+    state: absent
+    path: "/etc/localtime"
+
 - name: Set timezone
   timezone: name="{{ chrony_timezone }}"


### PR DESCRIPTION
This resolves an issue we were seeing in the DeepOps Vagrant tests where the /etc/timezone file is marked as immutable in CentOS. Before updating the timezone it was necessary to remove or change the permissions on this file. The next task immediately updates/resets this file.